### PR TITLE
Fix php 8.0 deprecation

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -439,7 +439,7 @@ if ( ! function_exists( 'shapely_author_bio' ) ) {
 		$author_fullname          = ( '' != get_the_author_meta( 'first_name' ) && '' != get_the_author_meta( 'last_name' ) ) ? get_the_author_meta( 'first_name' ) . ' ' . get_the_author_meta( 'last_name' ) : '';
 		$author_email             = get_the_author_meta( 'email' );
 		$author_description       = get_the_author_meta( 'description' );
-		$author_name              = (( '' != trim( $author_nickname ) ) ? $author_nickname : ( trim( $author_displayname ) != '' )) ? $author_displayname : $author_fullname;
+		$author_name		  =  '' != trim($author_nickname) ? $author_nickname : ('' != trim($author_displayname) ?  $author_displayname : $author_fullname);
 		$show_athor_email         = get_theme_mod( 'post_author_email', false );
 		$show_project_athor_email = get_theme_mod( 'project_author_email', false );
 		?>


### PR DESCRIPTION
This commit fixes this issue that appears in v8.0 php: PHP Error : Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)`