### PR TITLE
Fix the two faults behind the broken demo: WP_Error terms and the Font Awesome handle collision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,11 @@ jobs:
 
       - name: Install PHPCS + standards
         run: |
+          # phpcodesniffer-composer-installer is a Composer plugin, and Composer
+          # refuses to run plugins that are not explicitly allow-listed. Without
+          # this the require aborts before PHPCS is ever installed.
+          composer global config --no-plugins --no-interaction \
+            allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
           composer global require --no-interaction --no-progress \
             squizlabs/php_codesniffer \
             phpcompatibility/php-compatibility \

--- a/functions.php
+++ b/functions.php
@@ -288,8 +288,16 @@ function shapely_scripts() {
 	// Add Bootstrap default CSS
 	wp_enqueue_style( 'bootstrap', $uri . '/assets/css/bootstrap.min.css', array(), '3.3.7' );
 
-	// Replace old Font Awesome with Font Awesome 6
-	wp_enqueue_style( 'font-awesome', $uri . '/assets/css/fontawesome6/all.min.css', array(), '6.4.2' );
+	/*
+	 * Registered under a theme-specific handle rather than the generic
+	 * 'font-awesome'. WordPress deduplicates by handle, so whichever plugin
+	 * registers 'font-awesome' first wins and every later enqueue is silently
+	 * a no-op. Elementor ships Font Awesome 4.7 under exactly that handle, so
+	 * on any site running it the theme's Font Awesome 6 never loaded at all --
+	 * and the theme's fa-brands / fa-solid classes do not exist in 4.x, which
+	 * is why the social, search and menu icons rendered as blank boxes.
+	 */
+	wp_enqueue_style( 'shapely-font-awesome', $uri . '/assets/css/fontawesome6/all.min.css', array(), '6.4.2' );
 
 	// Add Google Fonts
 	wp_enqueue_style( 'shapely-fonts', 'https://fonts.googleapis.com/css?family=Raleway:100,300,400,500,600,700&display=swap', array(), null );

--- a/inc/class-shapely-related-posts.php
+++ b/inc/class-shapely-related-posts.php
@@ -143,6 +143,20 @@ if ( ! class_exists( 'Shapely_Related_Posts' ) ) {
 				$types      = wp_get_object_terms( get_the_ID(), 'jetpack-portfolio-type', $terms_args );
 				$tags       = wp_get_object_terms( get_the_ID(), 'jetpack-portfolio-tag', $terms_args );
 
+				/*
+				 * These return WP_Error when the taxonomy is not registered, which
+				 * happens whenever whatever supplied the portfolio post type is
+				 * deactivated while its posts remain. ! empty() is true for an
+				 * object, so without this the WP_Error was pushed straight into
+				 * tax_query and WP_Query silently returned the wrong posts.
+				 */
+				if ( is_wp_error( $types ) ) {
+					$types = array();
+				}
+				if ( is_wp_error( $tags ) ) {
+					$tags = array();
+				}
+
 				$tax_query = array();
 
 				if ( ! empty( $types ) ) {

--- a/inc/libraries/epsilon-framework/class-epsilon-framework.php
+++ b/inc/libraries/epsilon-framework/class-epsilon-framework.php
@@ -259,7 +259,16 @@ class Epsilon_Framework {
 			'row'        => esc_html__( 'Row', 'shapely' ),
 		) );
 
-		wp_enqueue_style( 'font-awesome', EPSILON_URI . '../../assets/css/fontawesome6/all.min.css' );
+		/*
+		 * Two faults here, both fixed in place (this library is vendored, not a
+		 * submodule). EPSILON_URI already ends in .../inc/libraries/epsilon-framework/,
+		 * so '../../' resolved to .../inc/assets/css/... -- one level short of the
+		 * theme root, and a 404, which is why the customizer's own icons were
+		 * missing. And the generic 'font-awesome' handle collides with the one
+		 * Elementor and others register, making this a silent no-op on those sites.
+		 * Reuse the theme's handle so both screens load the same file once.
+		 */
+		wp_enqueue_style( 'shapely-font-awesome', get_template_directory_uri() . '/assets/css/fontawesome6/all.min.css', array(), '6.4.2' );
 		wp_enqueue_style( 'epsilon-styles', EPSILON_URI . '/assets/css/style.css' );
 	}
 


### PR DESCRIPTION
Found while diagnosing the fatal on <https://colorlibhub.com/shapely/> (fixed in shapely-companion [#42](https://github.com/ColorlibHQ/shapely-companion/pull/42)). The theme has the same unguarded pattern.

`wp_get_object_terms()` returns a `WP_Error` when the taxonomy is not registered — the case whenever whatever supplied the portfolio post type is deactivated while its posts remain. `! empty()` is **true** for an object, so the `WP_Error` was pushed straight into `tax_query`:

```php
$types = wp_get_object_terms( get_the_ID(), 'jetpack-portfolio-type', $terms_args );
if ( ! empty( $types ) ) {                    // true for WP_Error
    array_push( $tax_query, array( 'terms' => $types, ... ) );
}
```

**Not fatal here** — unlike the plugin's Portfolio widget, which passed the `WP_Error` to `implode()` and raised a TypeError that truncated the page. The consequence is quieter: `WP_Query` receives a malformed `tax_query` and returns the wrong related posts instead of none.

Both `wp_get_object_terms()` calls are now checked with `is_wp_error()`. After this, all four term lookups across the theme are guarded (`archive-jetpack-portfolio.php` already was).

Verified: `php -l` clean across 85 files, front-end sweep shows all pages complete with 0 PHP notices and 0 JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)