### PR TITLE
Release 1.2.21 — Font Awesome never loaded alongside Elementor

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,11 @@
+= 1.2.21 =
+* Fixed the theme's Font Awesome 6 never loading on sites running Elementor or any other plugin that registers the generic "font-awesome" handle. WordPress keeps only the first registration of a handle, so the theme's stylesheet was silently dropped and every fa-brands / fa-solid icon -- the social links, the search button, the menu and pagination arrows -- rendered as a blank box. It now uses its own "shapely-font-awesome" handle
+* Fixed the customizer loading Font Awesome from .../shapely/inc/assets/css/..., a path that has never existed, so the customizer's own icons 404'd
+* Fixed related posts on portfolio items returning the wrong posts when the portfolio taxonomies are not registered: wp_get_object_terms() returns a WP_Error there, and it was being passed straight into the query
+* Regenerated languages/shapely.pot, which had been built before the text domain unification and was missing 86 translatable strings
+* Added a version check to the build so style.css, readme.txt, changelog.txt and package.json can no longer drift apart (readme.txt had been left at 1.2.19)
+* Fixed the coding-standards CI job, which had been failing to install PHPCS rather than actually checking anything
+
 = 1.2.20 =
 * PHP 8.5 compatibility: removed every runtime deprecation and warning raised by the theme
 * Verified on WordPress 7.0.2 / PHP 8.5: zero PHP notices across all templates, the customizer, the welcome screen and the block editor

--- a/languages/shapely.pot
+++ b/languages/shapely.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GNU General Public License v3.
 msgid ""
 msgstr ""
-"Project-Id-Version: Shapely 1.2.20 1.2.20\n"
+"Project-Id-Version: Shapely 1.2.21\n"
 "Report-Msgid-Bugs-To: https://www.colorlib.com/\n"
 "Last-Translator: Colorlib <office@colorlib.com>\n"
 "Language-Team: Colorlib <office@colorlib.com>\n"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shapely",
-  "version": "1.2.20",
+  "version": "1.2.21",
   "description": "Build and lint tooling for the Shapely WordPress theme.",
   "homepage": "https://www.colorlib.com",
   "author": "Colorlib",
@@ -25,9 +25,10 @@
     "i18n": "node tools/make-pot.mjs",
     "i18n:check": "node tools/check-textdomain.mjs",
     "images": "node tools/optimize-images.mjs",
-    "prebuild": "npm run i18n:check",
+    "prebuild": "npm-run-all i18n:check version:check",
     "build": "node tools/build-zip.mjs",
-    "verify": "npm-run-all lint i18n:check"
+    "verify": "npm-run-all lint i18n:check version:check",
+    "version:check": "node tools/check-version.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/readme.txt
+++ b/readme.txt
@@ -67,6 +67,14 @@ This page template is used to create the Parallax homepage from our demo : https
 
 == Changelog ==
 
+= 1.2.21 =
+* Fixed the theme's Font Awesome 6 never loading on sites running Elementor or any other plugin that registers the generic "font-awesome" handle. WordPress keeps only the first registration of a handle, so the theme's stylesheet was silently dropped and every fa-brands / fa-solid icon -- the social links, the search button, the menu and pagination arrows -- rendered as a blank box. It now uses its own "shapely-font-awesome" handle
+* Fixed the customizer loading Font Awesome from .../shapely/inc/assets/css/..., a path that has never existed, so the customizer's own icons 404'd
+* Fixed related posts on portfolio items returning the wrong posts when the portfolio taxonomies are not registered: wp_get_object_terms() returns a WP_Error there, and it was being passed straight into the query
+* Regenerated languages/shapely.pot, which had been built before the text domain unification and was missing 86 translatable strings
+* Added a version check to the build so style.css, readme.txt, changelog.txt and package.json can no longer drift apart (readme.txt had been left at 1.2.19)
+* Fixed the coding-standards CI job, which had been failing to install PHPCS rather than actually checking anything
+
 = 1.2.20 =
 * PHP 8.5 compatibility: removed every runtime deprecation and warning raised by the theme
 * Verified on WordPress 7.0.2 / PHP 8.5: zero PHP notices across all templates, the customizer, the welcome screen and the block editor
@@ -194,4 +202,4 @@ This page template is used to create the Parallax homepage from our demo : https
 = 1.0.0 - March 26 2016 =
 * Initial release
 
-Stable tag: 1.2.19
+Stable tag: 1.2.21

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://colorlib.com/wp/themes/shapely/
 Author: Colorlib
 Author URI: https://colorlib.com
 Description: Shapely is a one-page WordPress theme for business, portfolio and small e-commerce sites. The front page is assembled from widgets, so you can stack parallax sections, a portfolio grid, testimonials, a client logo carousel, a call to action and a contact block in whatever order you need. It also ships conventional blog templates with a choice of left, right, full-width or no sidebar, four footer widget areas, and a social icon menu. WooCommerce and Jetpack are supported, and the theme is translation ready.
-Version: 1.2.20
+Version: 1.2.21
 Requires at least: 6.4
 Tested up to: 7.0
 Requires PHP: 7.4

--- a/tools/check-version.mjs
+++ b/tools/check-version.mjs
@@ -1,0 +1,34 @@
+/**
+ * Fail the build when the version is not the same in all four places.
+ *
+ * The theme carries its version in style.css (the only file WordPress actually
+ * reads it from), readme.txt, changelog.txt and package.json. Nothing checked
+ * that they agreed, and they had already drifted: readme.txt's Stable tag sat
+ * at 1.2.19 while the theme shipped 1.2.20.
+ */
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const ROOT = path.resolve(import.meta.dirname, '..');
+const read = (f) => readFile(path.join(ROOT, f), 'utf8');
+
+const style = (await read('style.css')).match(/^\s*Version:\s*(.+)$/m)?.[1].trim() ?? '';
+const readme = (await read('readme.txt')).match(/^Stable tag:\s*(.+)$/m)?.[1].trim() ?? '';
+// changelog.txt is newest-first, so the first "= x.y.z =" heading is the release.
+const changelog = (await read('changelog.txt')).match(/^=\s*([0-9][^=\s]*)\s*=/m)?.[1].trim() ?? '';
+const pkg = JSON.parse(await read('package.json')).version ?? '';
+
+const rows = [
+  ['style.css      Version', style],
+  ['readme.txt     Stable tag', readme],
+  ['changelog.txt  latest entry', changelog],
+  ['package.json   version', pkg],
+];
+rows.forEach(([label, v]) => console.log(`  ${label.padEnd(30)} ${v || '(missing)'}`));
+
+const unique = [...new Set(rows.map(([, v]) => v))];
+if (unique.length !== 1 || !unique[0]) {
+  console.error(`\n  version mismatch: ${unique.join(' / ')}`);
+  process.exit(1);
+}
+console.log(`\n  versions agree: ${style}`);

--- a/tools/make-pot.mjs
+++ b/tools/make-pot.mjs
@@ -35,7 +35,12 @@ try {
 const args = [
   'i18n', 'make-pot', ROOT, DEST,
   '--domain=shapely',
-  '--package-name=' + `Shapely ${version}`.trim(),
+  /*
+   * Just the name. WP-CLI reads the version out of style.css and appends it
+   * itself, so passing "Shapely 1.2.20" here produced the doubled
+   * "Project-Id-Version: Shapely 1.2.20 1.2.20".
+   */
+  '--package-name=Shapely',
   '--exclude=node_modules,vendor,build,tools,src,.github',
   '--headers=' + JSON.stringify({
     'Report-Msgid-Bugs-To': 'https://www.colorlib.com/',


### PR DESCRIPTION
Cuts 1.2.21 with the fixes behind the broken demo at https://colorlibhub.com/shapely/.

## What was wrong

The demo had two independent faults. The first was a PHP fatal in the companion
plugin's Portfolio widget, already fixed and released as **Shapely Companion
1.2.12**. This PR carries the second.

**Font Awesome never loaded.** The theme enqueued its Font Awesome 6 under the
generic `font-awesome` handle. WordPress keeps only the first registration of a
handle, and Elementor registers `font-awesome` for the Font Awesome 4.7 it
bundles — so on the demo, and on any site running Elementor, the theme's icon
font was silently dropped:

```
id='font-awesome-css' href='.../elementor/assets/lib/font-awesome/css/font-awesome.min.css?ver=4.7.0'
```

The theme's markup uses `fa-brands`, `fa-solid`, `fa-x-twitter` and
`fa-mobile-screen`, none of which exist in Font Awesome 4, so the social links,
search button, menu and pagination arrows all rendered as blank boxes.

Reproduced locally by registering `font-awesome` at priority 1 the way Elementor
does, then counting the theme's stylesheet on the page:

| | theme FA6 stylesheets on page |
|---|---|
| before | **0** |
| after | **1** |

**The customizer had the same problem plus a broken path.** The vendored Epsilon
framework enqueued `EPSILON_URI . '../../assets/css/fontawesome6/all.min.css'`,
which resolves to `.../shapely/inc/assets/css/...` — one directory short of the
theme root, and a file that has never existed. So the customizer 404'd on its
own icons regardless of the handle collision.

## Also in this release

- Related posts on portfolio items returned the wrong posts when the portfolio
  taxonomies are unregistered — `wp_get_object_terms()` returns a `WP_Error`
  there, and `! empty()` is true for an object, so it went straight into
  `tax_query`.
- Regenerated `languages/shapely.pot`, which predated the text domain
  unification and was missing 86 strings.
- Added `tools/check-version.mjs`. `readme.txt` had drifted to 1.2.19 while the
  theme shipped 1.2.20 because nothing compared the four version files.
- Fixed `make-pot.mjs` emitting `Project-Id-Version: Shapely 1.2.20 1.2.20`.
- Fixed the coding-standards CI job, which had been failing to install PHPCS
  rather than checking anything.

## Verification

`npm run verify` clean (0 errors), `php -l` across 85 files, build produces a
243-file zip with no developer files and version 1.2.21 throughout.

Note for child themes: anything calling `wp_dequeue_style( 'font-awesome' )` to
swap the icon set needs the new `shapely-font-awesome` handle. The theme's other
generic handles (`bootstrap`, `flexslider`, `owl.carousel`) carry the same
collision risk but are deliberately left alone — they are not currently broken
anywhere, and renaming them would break dequeues for no present benefit.