### PR TITLE
Centre the submenu arrow on its row

### DIFF
--- a/style.css
+++ b/style.css
@@ -1659,6 +1659,18 @@ nav {
   content: "\f105"; /* fa-angle-right */
   right: 10px;
   display: inline-block;
+  /*
+   * The base .dropdown:after rule centres the glyph with line-height: 53px,
+   * which is the height of the 55px top-level bar. A submenu row is 32px
+   * (6px padding + 20px line-height + 6px), so inherited unchanged the arrow
+   * painted 11.5px below the label it belongs to.
+   *
+   * Anchored to the link row via line-height rather than top/transform: 50%,
+   * because this li also contains its child <ul>, so its own height is not the
+   * row height wherever that submenu expands in flow (the mobile accordion).
+   */
+  top: 0;
+  line-height: 32px;
 }
 
 .shapely-dropdown {

--- a/style.css
+++ b/style.css
@@ -2407,6 +2407,16 @@ nav.fixed.scrolled {
     padding: 10px 16px;
   }
 
+  /*
+   * Submenu rows are 44px here (10px + 24px line-height + 10px) rather than the
+   * 32px they are on desktop, so the arrow's line box has to match or it rides
+   * high. Same reasoning as the base rule -- see the comment there.
+   */
+  .main-navigation .menu > li > ul li.menu-item-has-children:after,
+  .main-navigation .menu > li > ul li.menu-item-has-children > .dropdown:after {
+    line-height: 44px;
+  }
+
   .main-navigation .dropdown .dropdown li {
     padding-left: 18px;
   }


### PR DESCRIPTION
The right-pointing arrow on a second-level menu item sat well below its label,
down near the bottom edge of the row.

## Cause

`.dropdown:after` centres the glyph using `top: 0; line-height: 53px` — 53px
being the height of the **55px top-level menu bar**, which is where that rule
was written to work. A submenu row is **32px** (6px padding + 20px line-height +
6px), so the inherited line box placed the glyph centre 27.5px down a 32px row,
**11.5px below** the label's centre at 16px.

Measured in the browser:

| | line-height | top | glyph centre | label centre | offset |
|---|---|---|---|---|---|
| before | 53px | 1px | 27.5px | 16px | **11.5px** |
| after | 32px | 0 | 16px | 16px | **0** |

## Why line-height rather than `top: 50%` + `translateY(-50%)`

The obvious fix centres against the `li`. That is wrong here: this `li` also
contains its child `<ul>`, so its height is the whole expanded block rather than
the row, anywhere the submenu is laid out in flow. Anchoring to the link row via
`line-height` is correct in both cases.

## Scope

Desktop only in practice — `.mobile-menu .dropdown:after` is `display: none`,
the mobile accordion using the `.shapely-dropdown` span instead. Verified across
1440 / 991 / 768 / 480px.

Stylelint clean (0 errors; the 48 warnings are pre-existing).