### PR TITLE
Centre the back-to-top arrow in its button

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 = 1.2.21 =
+* Fixed the back-to-top arrow sitting off-centre in its button. The 36px button's content box was 22px tall and 10px wide after border and padding, so a 18px glyph with a 27px line box could not centre on either axis; measured 2.8px right and 1.9px high before, sub-pixel after
 * Fixed one-page section links in the menu, and the page-builder customizer, using site_url() where home_url() was meant. On installs with WordPress in its own subdirectory those pointed at /wp/ instead of the site address
 * Added add_theme_support( 'wp-block-styles' ) and add_editor_style(), so core block styles apply on the front end and the editor canvas matches the theme's typography
 * Added three block styles (two button styles and a short rule) and two block patterns, built from the theme's own button and colour values

--- a/readme.txt
+++ b/readme.txt
@@ -68,6 +68,7 @@ This page template is used to create the Parallax homepage from our demo : https
 == Changelog ==
 
 = 1.2.21 =
+* Fixed the back-to-top arrow sitting off-centre in its button. The 36px button's content box was 22px tall and 10px wide after border and padding, so a 18px glyph with a 27px line box could not centre on either axis; measured 2.8px right and 1.9px high before, sub-pixel after
 * Fixed one-page section links in the menu, and the page-builder customizer, using site_url() where home_url() was meant. On installs with WordPress in its own subdirectory those pointed at /wp/ instead of the site address
 * Added add_theme_support( 'wp-block-styles' ) and add_editor_style(), so core block styles apply on the front end and the editor canvas matches the theme's typography
 * Added three block styles (two button styles and a short rule) and two block patterns, built from the theme's own button and colour values

--- a/style.css
+++ b/style.css
@@ -3563,7 +3563,22 @@ footer.bg-dark a {
   -webkit-transform: translateX(-50%);
   height: 36px;
   width: 36px;
-  padding: 5px 11px;
+  /*
+   * Centred with flex rather than padding + line-height. The button is a fixed
+   * 36px box, so with a 2px border and 5px/11px padding the content box was
+   * 22px tall and 10px wide -- while the glyph is 18px with a 27px line box
+   * inherited from .btn-sm. Neither axis could centre: the arrow sat 1px high
+   * and 3.4px right of centre, measured on the rendered button.
+   *
+   * letter-spacing is reset because .btn adds 1px after every character,
+   * including the last, which offsets any centred single glyph by half that.
+   */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  line-height: 1;
+  letter-spacing: 0;
 }
 
 .back-to-top .fa {


### PR DESCRIPTION
The up arrow in `<a class="btn btn-sm fade-half back-to-top inner-link">` sat off-centre.

## Cause

The button is a fixed **36px** box. After `.btn`'s 2px border and `.back-to-top`'s `5px 11px` padding the content box is **22px tall and 10px wide** — but the glyph is 18px, carrying a **27px** line box inherited from `.btn-sm`.

Neither axis could centre: the line box overflows vertically, and an 18px glyph cannot centre inside a 10px content box.

Glyph ink measured relative to the button centre:

| | dx | dy |
|---|---|---|
| before | **+2.75px** | **−1.88px** |
| after | −0.12px | +0.12px |

## Fix

Centred with flex rather than padding + line-height arithmetic, so it no longer depends on the glyph's metrics happening to match the box.

`letter-spacing` is reset too — `.btn` adds 1px after *every* character including the last, which offsets any centred single glyph by half that, and was part of the horizontal error.

`.screen-reader-text` was checked and ruled out: it is `position: absolute`, so it never participated in the line box.